### PR TITLE
Add TimeBoxedOperations so we can timebox the resolving of artifacts

### DIFF
--- a/resolver/src/main/java/nl/ordina/jtech/maven/analyzer/aether/Booter.java
+++ b/resolver/src/main/java/nl/ordina/jtech/maven/analyzer/aether/Booter.java
@@ -34,7 +34,7 @@ public class Booter {
     public static DefaultRepositorySystemSession newRepositorySystemSession(RepositorySystem system) {
         MavenRepositorySystemSession session = new MavenRepositorySystemSession();
 
-        LocalRepository localRepo = new LocalRepository("target/local-repo");
+        LocalRepository localRepo = new LocalRepository("~/local-repo");
         session.setLocalRepositoryManager(system.newLocalRepositoryManager(localRepo));
 
         return session;

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -56,6 +56,11 @@
 			<groupId>org.scalaj</groupId>
 			<artifactId>scalaj-http_2.10</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.scalatest</groupId>
+			<artifactId>scalatest_2.10</artifactId>
+			<version>3.0.0-M15</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/spark/src/main/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxed.scala
+++ b/spark/src/main/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxed.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext.Implicits._
 object TimeBoxed {
   class TimeBoxedOperation[A](f: => A) {
     def get(implicit timeout: Duration) =
-      Try(Await.result(Future(f), timeout)).get
+      Await.result(Future(f), timeout)
     def recover(default: A)(implicit timeout: Duration) =
       Try(Await.result(Future(f), timeout)).getOrElse(default)
   }

--- a/spark/src/main/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxed.scala
+++ b/spark/src/main/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxed.scala
@@ -1,0 +1,17 @@
+package nl.ordina.jtech.mavendependencygraph.spark
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import scala.util._
+import scala.concurrent.ExecutionContext.Implicits._
+
+object TimeBoxed {
+  class TimeBoxedOperation[A](f: => A) {
+    def get(implicit timeout: Duration) =
+      Try(Await.result(Future(f), timeout)).get
+    def recover(default: A)(implicit timeout: Duration) =
+      Try(Await.result(Future(f), timeout)).getOrElse(default)
+  }
+
+  def apply[A](f: => A): TimeBoxedOperation[A] = new TimeBoxedOperation(f)
+}

--- a/spark/src/test/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxedSpec.scala
+++ b/spark/src/test/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxedSpec.scala
@@ -1,0 +1,29 @@
+package nl.ordina.jtech.mavendependencygraph.spark
+
+import org.scalatest._
+
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration._
+
+class TimeBoxedSpec extends FunSuite {
+  implicit val timeout = 10 milliseconds
+  val durationThatTimesOut = 20L
+
+  test("TimeBoxedOperations that exceed their duration should fail with a timeout") {
+    intercept[TimeoutException](TimeBoxed {
+      Thread.sleep(durationThatTimesOut)
+    }.get)
+  }
+
+  test("TimeBoxedOperations that exceed their duration should be able to fallback to a default value") {
+    println(timeout)
+    val result = TimeBoxed {
+      Thread.sleep(durationThatTimesOut)
+      false
+    } recover {
+      true
+    }
+
+    assert(result)
+  }
+}

--- a/spark/src/test/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxedSpec.scala
+++ b/spark/src/test/scala/nl/ordina/jtech/mavendependencygraph/spark/TimeBoxedSpec.scala
@@ -9,6 +9,13 @@ class TimeBoxedSpec extends FunSuite {
   implicit val timeout = 10 milliseconds
   val durationThatTimesOut = 20L
 
+  test("TimeBoxedOperations that do not exceed their duration should just return the result") {
+    val result = TimeBoxed {
+      true
+    }.get(1 seconds)
+    assert(result)
+  }
+
   test("TimeBoxedOperations that exceed their duration should fail with a timeout") {
     intercept[TimeoutException](TimeBoxed {
       Thread.sleep(durationThatTimesOut)


### PR DESCRIPTION
We can use this construct to put a timebox around the resolving operation. However, we should rather improve the code that resolves the artifact itself, because there is where the actual problem resides. 
